### PR TITLE
Make minitest-documentation play nice with others

### DIFF
--- a/lib/minitest/documentation_plugin.rb
+++ b/lib/minitest/documentation_plugin.rb
@@ -9,7 +9,7 @@ module Minitest
 
   def self.plugin_documentation_init options
     if Documentation.documentation?
-      io = options.delete(:io) || $stdout
+      io = options.fetch(:io, $stdout)
       self.reporter.reporters.reject! {|o| o.is_a? ProgressReporter }
       self.reporter.reporters << Documentation.new(io, options)
     end


### PR DESCRIPTION
Plugins are not provided with unique copies of the `options` Hash, so when you delete `:io` from that, you prevent any other outputter from working. This fixes that.

(It’s arguable whether you should be removing any `ProgressReporter` as well, but that didn’t cause failure on output.)