### PR TITLE
Now to apply the documentation format, --documentation has to be passed.

### DIFF
--- a/lib/minitest/documentation.rb
+++ b/lib/minitest/documentation.rb
@@ -1,4 +1,3 @@
 require 'minitest'
 
 Minitest.load_plugins
-Minitest::Documentation.documentation!


### PR DESCRIPTION
Seems to me that the documentation format was always applied, regardless of the --documentation option.
Now without --documentation, it is not applied, with --documentation it is.

Hope I did not break anything though, still new in Ruby.
